### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 日本の補助金情報を検索するための MCP (Model Context Protocol) サーバー
 
+<a href="https://glama.ai/mcp/servers/@tachibanayu24/jgrants-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@tachibanayu24/jgrants-mcp/badge" alt="jgrants-mcp MCP server" />
+</a>
+
 ## 概要
 
 jgrants-mcp は、jGrants（デジタル庁が運営する補助金電子申請システム）の公開 API をラップした MCP サーバーです。LLM から MCP を経由して日本の補助金情報に簡単にアクセスできます。


### PR DESCRIPTION
This PR adds a badge for the [jgrants-mcp](https://glama.ai/mcp/servers/@tachibanayu24/jgrants-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@tachibanayu24/jgrants-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@tachibanayu24/jgrants-mcp/badge" alt="jgrants-mcp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.